### PR TITLE
Improve authentication error handling

### DIFF
--- a/server/src/db/users.rs
+++ b/server/src/db/users.rs
@@ -72,9 +72,9 @@ impl FromRow for (Key, String, User) {
 pub(crate) fn login(
     conn: &rusqlite::Connection,
     login_credentials: LoginCredentials,
-) -> Result<(Key, String, User), DbError> {
+) -> Result<Option<(Key, String, User)>, DbError> {
     let email = login_credentials.email.trim();
-    sqlite::one(
+    sqlite::one_optional(
         &conn,
         r#"
            select id, email, username, password, ui_config_json

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use actix_web::{HttpResponse, ResponseError};
+use actix_web::{HttpResponse, ResponseError, http::StatusCode};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -76,10 +76,18 @@ pub enum Error {
 }
 
 impl ResponseError for Error {
-    fn error_response(&self) -> HttpResponse {
-        match *self {
-            Error::NotFound => HttpResponse::NotFound().finish(),
-            _ => HttpResponse::InternalServerError().finish(),
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Error::NotFound => StatusCode::NOT_FOUND,
+            Error::Authenticating => StatusCode::UNAUTHORIZED,
+            Error::Registration | Error::BadUpload => StatusCode::BAD_REQUEST,
+            Error::TooManyFound => StatusCode::CONFLICT,
+            Error::ExternalServerError => StatusCode::BAD_GATEWAY,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        HttpResponse::build(self.status_code()).finish()
     }
 }


### PR DESCRIPTION
## Summary
- return proper HTTP status codes for authentication and related client errors
- treat missing login records as authentication failures instead of server faults

## Testing
- cargo test --manifest-path server/Cargo.toml

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69135ca14b1083338c2027a8ee985e02)