### PR TITLE
Use Qry helpers for sqlite queries

### DIFF
--- a/server/src/db/bookmarks.rs
+++ b/server/src/db/bookmarks.rs
@@ -40,10 +40,10 @@ pub(crate) fn create_bookmark(
     user_id: Key,
     deck_id: Key,
 ) -> Result<(), DbError> {
-    let stmt = "INSERT INTO bookmarks(user_id, deck_id) VALUES (:user_id, :deck_id)";
+    let stmt = Qry::insert("bookmarks(user_id, deck_id)").values("(:user_id, :deck_id)");
     sqlite::zero(
         &conn,
-        stmt,
+        &stmt,
         named_params! {":user_id": user_id, ":deck_id": deck_id},
     )
 }
@@ -55,11 +55,11 @@ pub(crate) fn create_multiple_bookmarks(
 ) -> Result<(), DbError> {
     let tx = conn.transaction()?;
 
-    let stmt = "INSERT INTO bookmarks(user_id, deck_id) VALUES (:user_id, :deck_id)";
+    let stmt = Qry::insert("bookmarks(user_id, deck_id)").values("(:user_id, :deck_id)");
     for deck_id in deck_ids {
         sqlite::zero(
             &tx,
-            stmt,
+            &stmt,
             named_params! {":user_id": user_id, ":deck_id": deck_id},
         )?;
     }
@@ -89,10 +89,12 @@ pub(crate) fn delete_bookmark(
     user_id: Key,
     bookmark_id: Key,
 ) -> Result<(), DbError> {
-    let stmt = "DELETE FROM bookmarks WHERE user_id = :user_id and id = :bookmark_id";
+    let stmt = Qry::delete_from("bookmarks")
+        .where_clause("user_id = :user_id")
+        .and("id = :bookmark_id");
     sqlite::zero(
         &conn,
-        stmt,
+        &stmt,
         named_params! {":user_id": user_id, ":bookmark_id": bookmark_id},
     )
 }

--- a/server/src/db/qry.rs
+++ b/server/src/db/qry.rs
@@ -139,12 +139,26 @@ impl Qry {
         self.add(" OFFSET :offset ")
     }
 
+    pub fn insert(part: &str) -> Self {
+        Self {
+            s: "INSERT INTO ".to_owned(),
+        }
+        .add(part)
+    }
+
     pub fn insert_into(self, part: &str) -> Self {
         self.prefix_add(" INSERT INTO ", part)
     }
 
     pub fn values(self, part: &str) -> Self {
         self.prefix_add(" VALUES ", part)
+    }
+
+    pub fn delete_from(part: &str) -> Self {
+        Self {
+            s: "DELETE FROM ".to_owned(),
+        }
+        .add(part)
     }
 
     pub fn returning(self, part: &str) -> Self {
@@ -158,9 +172,7 @@ impl Qry {
     }
 
     pub fn query_decklike_generic() -> Qry {
-        Qry::select_decklike()
-            .from_decklike()
-            .where_decklike()
+        Qry::select_decklike().from_decklike().where_decklike()
     }
 
     pub fn query_decklike_all_ordered(order_clause: &str) -> Qry {

--- a/server/src/db/quotes.rs
+++ b/server/src/db/quotes.rs
@@ -92,8 +92,8 @@ pub(crate) fn get_or_create(
 
     sqlite::zero(
         &tx,
-        "INSERT INTO notes(user_id, deck_id, kind, content)
-                  VALUES (:user_id, :deck_id, :kind, :content)",
+        &Qry::insert("notes(user_id, deck_id, kind, content)")
+            .values("(:user_id, :deck_id, :kind, :content)"),
         named_params! {":user_id": user_id, ":deck_id": deck.id, ":kind": NoteKind::Note, ":content": content},
     )?;
 


### PR DESCRIPTION
## Summary
- add query builder helpers for insert and delete operations
- rebuild bookmark, point, quote, and stats queries to use Qry composable methods instead of raw SQL strings
- replace count queries with Qry::select_count chaining
- remove the unused Clone derive from the Qry builder

## Testing
- cargo fmt


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69202d2621b08333aa9b6a4d700a00f5)