### PR TITLE
Improve session key validation and secure cookie defaults

### DIFF
--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -61,6 +61,10 @@ pub enum Error {
     SessionGetError(#[from] actix_session::SessionGetError),
     #[error(transparent)]
     SessionInsertError(#[from] actix_session::SessionInsertError),
+    #[error("SESSION_SIGNING_KEY must be {expected} hex characters, found {found}")]
+    InvalidSessionSigningKeyLength { expected: usize, found: usize },
+    #[error("SESSION_SIGNING_KEY contains invalid hex characters")]
+    InvalidSessionSigningKeyFormat,
     #[error("string conversion to enum")]
     StringConversionToEnum,
     #[error(transparent)]


### PR DESCRIPTION
## Summary
- validate `SESSION_SIGNING_KEY` length/format at startup and build the actix session key from parsed bytes instead of continuing with zeroed data
- keep session cookie SameSite strict but default `COOKIE_OVER_HTTPS_ONLY` to true so cookies are secure by default

## Testing
- cargo test *(fails: unable to download crates.io index due to 403 from CONNECT tunnel)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692054176c1083338b12038a821bb9ba)